### PR TITLE
fixed wrong sync word for SX127X chips

### DIFF
--- a/Code/GroundStation/GroundStation.ino
+++ b/Code/GroundStation/GroundStation.ino
@@ -33,7 +33,7 @@
 #define BANDWIDTH         125.0   // kHz
 #define SPREADING_FACTOR  11
 #define CODING_RATE       8       // 4/8
-#define SYNC_WORD_7X      0xFF    // sync word when using SX127x
+#define SYNC_WORD_7X      0x00    // sync word when using SX127x
 #define SYNC_WORD_6X      0x0F0F  //                      SX126x
 
 // set up radio module


### PR DESCRIPTION
#### Summary of changes
SX126X are able to decode the frame but SX127X can't. After a thorough inspection, it seems the sync words aren't doing what they should. We used Dani EA4GPZ decoded frame to compare against different sync word behaviours and concluded the most similar one is 0x00.

Sources:    
https://revspace.nl/DecodingLora#sync_word    
https://twitter.com/yl3ct/status/1203771916504436736